### PR TITLE
Composer: package compatibility with PHP 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": "~5.4 || ~7.0",
+        "php": "~5.4 || ~7.0 || ~8.0",
         "ext-curl": "*"
     },
-    "autoload": {        
+    "autoload": {
         "psr-4": { "pubsubhubbub\\publisher\\": "library/" }
     }
 }


### PR DESCRIPTION
Due to current requirements, this package can not be installed with PHP 8.0 through Composer.

There is not any incompatibility with its current code and PHP 8.0, so let's just add that requirement.

Reference: https://github.com/nodiscc/Shaarli/pull/4#issuecomment-820650731